### PR TITLE
Rfl client cleanup

### DIFF
--- a/sorrydb/cli/run_rfl_client.py
+++ b/sorrydb/cli/run_rfl_client.py
@@ -6,8 +6,7 @@ import logging
 import sys
 from pathlib import Path
 
-from sorrydb.clients.rfl_client.rfl_client import process_sorry_json
-
+from sorrydb.clients.rfl_client.rfl_client import process_sorries_json
 
 def main():
     parser = argparse.ArgumentParser(description="Reproduce a sorry with REPL.")
@@ -56,7 +55,7 @@ def main():
     # Print the "rfl" proof if succesful.
     try:
         logger.info(f"Processing sorry file: {sorry_file}")
-        proofs = process_sorry_json(sorry_file, lean_data)
+        proofs = process_sorries_json(sorry_file, lean_data)
         logger.info(f"Proofs: {proofs}")
         return 0
 

--- a/sorrydb/cli/run_rfl_client.py
+++ b/sorrydb/cli/run_rfl_client.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from sorrydb.clients.rfl_client.rfl_client import process_sorries_json
 
+
 def main():
     parser = argparse.ArgumentParser(description="Reproduce a sorry with REPL.")
     parser.add_argument(

--- a/sorrydb/cli/run_rfl_client.py
+++ b/sorrydb/cli/run_rfl_client.py
@@ -17,6 +17,12 @@ def main():
         help="Path to the sorry JSON file",
     )
     parser.add_argument(
+        "--output-file",
+        type=str,
+        required=True,
+        help="Path to the output JSON file",
+    )
+    parser.add_argument(
         "--lean-data",
         type=str,
         default=None,
@@ -49,14 +55,13 @@ def main():
 
     # Convert file names arguments to Path
     sorry_file = Path(args.sorry_file)
+    output_file = Path(args.output_file)
     lean_data = Path(args.lean_data) if args.lean_data else None
 
     # Process the sorry JSON file
-    # Print the "rfl" proof if succesful.
     try:
         logger.info(f"Processing sorry file: {sorry_file}")
-        proofs = process_sorries_json(sorry_file, lean_data)
-        logger.info(f"Proofs: {proofs}")
+        process_sorries_json(sorry_file, output_file, lean_data)
         return 0
 
     except FileNotFoundError as e:

--- a/sorrydb/clients/rfl_client/rfl_client.py
+++ b/sorrydb/clients/rfl_client/rfl_client.py
@@ -116,7 +116,7 @@ def try_rfl(repl: LeanRepl, sorry: Dict) -> str | None:
     logger.info(f"Found sorry with goal: {goal}")
 
     # Apply rfl to the proof_state_id
-    new_goals, new_proof_state_id = repl.apply_tactic(proof_state_id, "rfl")
+    new_proof_state_id, new_goals = repl.apply_tactic(proof_state_id, "rfl")
 
 
     # Verify that there are no goals left

--- a/sorrydb/clients/rfl_client/rfl_client.py
+++ b/sorrydb/clients/rfl_client/rfl_client.py
@@ -116,7 +116,7 @@ def try_rfl(repl: LeanRepl, sorry: Dict) -> str | None:
     logger.info(f"Found sorry with goal: {goal}")
 
     # Apply rfl to the proof_state_id
-    new_proof_state_id, new_goals = repl.apply_tactic(proof_state_id, "rfl")
+    _, new_goals = repl.apply_tactic(proof_state_id, "rfl")
 
 
     # Verify that there are no goals left

--- a/sorrydb/clients/rfl_client/rfl_client.py
+++ b/sorrydb/clients/rfl_client/rfl_client.py
@@ -10,7 +10,7 @@ from sorrydb.database.process_sorries import build_lean_project
 from sorrydb.utils.git_ops import prepare_repository
 from sorrydb.utils.lean_repo import build_lean_project
 from sorrydb.utils.repl_ops import LeanRepl, setup_repl
-from sorrydb.utils.verify import verify_sorry
+from sorrydb.utils.verify import verify_proof
 
 # Create a module-level logger
 logger = logging.getLogger(__name__)
@@ -85,7 +85,7 @@ def _process_sorries_with_lean_data(lean_data: Path, sorry_data: List[Dict]) -> 
  
         # If proof is not None, verify the proof
         if proof is not None:
-            if not verify_sorry(
+            if not verify_proof(
                 checkout_path,
                 sorry["repo"]["lean_version"],
                 sorry["location"],
@@ -129,7 +129,7 @@ def try_rfl(repl: LeanRepl, sorry: Dict) -> str | None:
 
 
 
-def process_sorry_json(
+def process_sorries_json(
     json_path: Path, lean_data_dir: Optional[Path] = None
 ) -> List[Optional[str]]:
     """Process a JSON with a list of sorries.

--- a/sorrydb/clients/rfl_client/rfl_client.py
+++ b/sorrydb/clients/rfl_client/rfl_client.py
@@ -42,6 +42,32 @@ def load_sorry_json(json_path: Path) -> Dict:
         raise
 
 
+def try_rfl(repl: LeanRepl, sorry: Dict) -> str | None:
+    """Try to apply rfl to a sorry.
+
+    Args:
+        repl: LeanRepl instance
+        sorry: Dict containing the sorry data
+
+    Returns:
+        str if rfl was applied successfully and no goals are left, None otherwise
+    """
+
+    # Locate sorry and obtain proof_state_id
+    proof_state_id, goal = repl.find_sorry_proof_state(sorry["location"])
+    logger.info(f"Found sorry with goal: {goal}")
+
+    # Apply rfl to the proof_state_id
+    _, new_goals = repl.apply_tactic(proof_state_id, "rfl")
+
+
+    # Verify that there are no goals left
+    if len(new_goals) > 0:
+        logger.info(f"New goals after rfl: {new_goals}")
+        return None
+    else:
+        logger.info("No goals left after rfl")
+        return "rfl"
 
 
 
@@ -100,32 +126,6 @@ def _process_sorries_with_lean_data(lean_data: Path, sorry_data: List[Dict]) -> 
 
     return output
 
-def try_rfl(repl: LeanRepl, sorry: Dict) -> str | None:
-    """Try to apply rfl to a sorry.
-
-    Args:
-        repl: LeanRepl instance
-        sorry: Dict containing the sorry data
-
-    Returns:
-        str if rfl was applied successfully and no goals are left, None otherwise
-    """
-
-    # Locate sorry and obtain proof_state_id
-    proof_state_id, goal = repl.find_sorry_proof_state(sorry["location"])
-    logger.info(f"Found sorry with goal: {goal}")
-
-    # Apply rfl to the proof_state_id
-    _, new_goals = repl.apply_tactic(proof_state_id, "rfl")
-
-
-    # Verify that there are no goals left
-    if len(new_goals) > 0:
-        logger.info(f"New goals after rfl: {new_goals}")
-        return None
-    else:
-        logger.info("No goals left after rfl")
-        return "rfl"
 
 
 

--- a/sorrydb/clients/rfl_client/rfl_client.py
+++ b/sorrydb/clients/rfl_client/rfl_client.py
@@ -41,6 +41,7 @@ def load_sorry_json(json_path: Path) -> Dict:
         logger.error(f"Invalid JSON in sorry file: {json_path}")
         raise
 
+
 def save_proofs_json(output_path: Path, output: List[Dict]):
     """Save the proofs to a JSON file.
 
@@ -74,7 +75,6 @@ def try_rfl(checkout_path: Path, repl: LeanRepl, sorry: Dict) -> str | None:
     # Apply rfl to the proof_state_id
     _, new_goals = repl.apply_tactic(proof_state_id, "rfl")
 
-
     # Verify that there are no goals left
     if len(new_goals) > 0:
         logger.info(f"New goals after rfl: {new_goals}")
@@ -83,19 +83,20 @@ def try_rfl(checkout_path: Path, repl: LeanRepl, sorry: Dict) -> str | None:
 
     # Verify that the proof typechecks
     if verify_proof(
-            checkout_path,
-            sorry["repo"]["lean_version"],
-            sorry["location"],
-            "rfl",
-        ):
+        checkout_path,
+        sorry["repo"]["lean_version"],
+        sorry["location"],
+        "rfl",
+    ):
         return "rfl"
     else:
         logger.info("Proof does not typecheck")
         return None
 
 
-
-def process_sorries_with_lean_data(lean_data: Path, sorry_data: List[Dict]) -> List[Dict]:
+def process_sorries_with_lean_data(
+    lean_data: Path, sorry_data: List[Dict]
+) -> List[Dict]:
     """Loop over list of sorries, prepare their repositories, and attempt to
     prove them using rfl.
 
@@ -109,7 +110,6 @@ def process_sorries_with_lean_data(lean_data: Path, sorry_data: List[Dict]) -> L
     output = []
     success_count = 0
     for sorry in sorry_data["sorries"]:
-
         # Prepare the repository (clone/checkout)
         checkout_path = prepare_repository(
             sorry["repo"]["remote"],
@@ -134,18 +134,16 @@ def process_sorries_with_lean_data(lean_data: Path, sorry_data: List[Dict]) -> L
                 proof = try_rfl(checkout_path, repl, sorry)
         except Exception as e:
             logger.warning(f"Error applying rfl: {e}")
- 
+
         # If proof is not None, verify the proof
         if proof is not None:
             success_count += 1
-        
+
         # Add output dict
         output.append(dict(sorry, proof=proof))
 
     logger.info(f"Solved {success_count} out of {len(sorry_data['sorries'])} sorries")
     return output
-
-
 
 
 def process_sorries_json(
@@ -183,4 +181,3 @@ def process_sorries_json(
 
     # Save the proofs to a JSON file
     save_proofs_json(json_output_path, output)
-

--- a/sorrydb/utils/repl_ops.py
+++ b/sorrydb/utils/repl_ops.py
@@ -264,3 +264,31 @@ class LeanRepl:
 
         # If we don't find the goal parent type, raise an exception
         raise RuntimeError(f"REPL tactic did not return parent type")
+
+    def find_sorry_proof_state(self, location: dict) -> Tuple[int, str]:
+        """Find the proof state of a sorry.
+
+        Args:
+            location: Dict containing the sorry location information
+
+        Returns:
+            Tuple of (proof state ID, goal)
+
+        Raises:
+            ReplError: if REPL returns an error
+            ValueError: if sorry cannot be found at given location
+        """
+        sorries = self.read_file(location["file"])
+    
+        # Find the sorry that matches the location
+        for sorry in sorries:
+            if (
+                sorry["location"]["start_line"] == location["start_line"]
+                and sorry["location"]["start_column"] == location["start_column"]
+                and sorry["location"]["end_line"] == location["end_line"]
+                and sorry["location"]["end_column"] == location["end_column"]
+            ):
+                logger.info(f"Found matching sorry at line {location['start_line']}")
+                return sorry["proof_state_id"], sorry["goal"]
+        logger.error("Could not find matching sorry")
+        raise ValueError(f"Could not find sorry at specified location: {location}")

--- a/sorrydb/utils/repl_ops.py
+++ b/sorrydb/utils/repl_ops.py
@@ -279,7 +279,7 @@ class LeanRepl:
             ValueError: if sorry cannot be found at given location
         """
         sorries = self.read_file(location["file"])
-    
+
         # Find the sorry that matches the location
         for sorry in sorries:
             if (


### PR DESCRIPTION
This PR cleans up the rfl_client code:
- various fixes to imports
- split out the processing code in smalle sub-routines
- move `find_sorry_proof_state` to `LenRepl` method in `repl_ops`
- output {sorry, proof} dicts to json file

Does not yet harmonise this with `llm_client`, also not yet documented (should be part of major rewrite of `README.md`).