### PR TITLE
feat: add `--max-sorries` option to `deduplicate_db`

### DIFF
--- a/doc/DATABASE-SCRIPTS.md
+++ b/doc/DATABASE-SCRIPTS.md
@@ -50,6 +50,22 @@ Now one can update the database regularly using:
 See [DEPLOY.md](DEPLOY.md) for instructions on running the database updater in a
 docker.
 
+### 4. Deduplicating the database
+
+After updating the database, you may want to deduplicate sorries that share the same goal.
+The `deduplicate` command removes duplicate sorries,
+keeping the most recently included version of each unique goal:
+
+`poetry run sorrydb deduplicate --database-path sorry_database.json`
+
+The `--max-sorries` option limits the number of sorries in the output:
+
+`poetry run sorrydb deduplicate --database-path sorry_database.json --max-sorries 100 --query-results-path 100_recent_varied_sorries.json`
+
+> [!NOTE]
+> When the output is limited `--max-sorries`, 
+> `deduplicate` prioritizes diversity of repositories and recent blame dates.
+
 ## Configuring `sorrydb`
 
 In addition to CLI argument,

--- a/sorrydb/cli/deduplicate_db.py
+++ b/sorrydb/cli/deduplicate_db.py
@@ -34,7 +34,7 @@ def deduplicate(
     max_sorries: Annotated[
         Optional[int],
         typer.Option(
-            help="Maximum number of sorries to add to deduplicated list",
+            help="Maximum number of sorries to add to deduplicated list. Favors recent sorries from varied repos.",
             show_default="No limit",
         ),
     ] = None,

--- a/sorrydb/cli/deduplicate_db.py
+++ b/sorrydb/cli/deduplicate_db.py
@@ -31,6 +31,13 @@ def deduplicate(
             dir_okay=False,
         ),
     ] = None,
+    max_sorries: Annotated[
+        Optional[int],
+        typer.Option(
+            help="Maximum number of sorries to add to deduplicated list",
+            show_default="No limit",
+        ),
+    ] = None,
 ):
     """
     Deduplicate the sorries in a SorryDB database.
@@ -39,7 +46,9 @@ def deduplicate(
 
     try:
         deduplicate_database(
-            database_path=database_path, query_results_path=query_results_path
+            database_path=database_path,
+            query_results_path=query_results_path,
+            max_sorries=max_sorries,
         )
         return 0
     except Exception as e:

--- a/sorrydb/database/deduplicate_database.py
+++ b/sorrydb/database/deduplicate_database.py
@@ -1,5 +1,6 @@
 import json
 from collections import defaultdict
+from itertools import islice, zip_longest
 from pathlib import Path
 from typing import Optional
 
@@ -25,9 +26,41 @@ def deduplicate_sorries_by_goal(sorries: list[Sorry]):
     ]
 
 
+def varied_repo_frequent_n_sorries(sorries: list[Sorry], n: int) -> list[Sorry]:
+    """
+    Takes `n` sorries from a list, while varying the source repo and favoring recent blame dates.
+
+    This is used to generate an interesting static benchmark at a given point.
+    """
+    # Group sorries by repository
+    repo_groups = defaultdict(list)
+    for sorry in sorries:
+        repo_groups[sorry.repo.remote].append(sorry)
+
+    # Sort each repository group by blame_date (most recent first)
+    for repo, repo_sorries in repo_groups.items():
+        repo_groups[repo] = sorted(
+            repo_sorries, key=lambda s: s.metadata.blame_date, reverse=True
+        )
+
+    # Create a generator for interleaved sorries from different repos
+    interleaved_sorries_generator = (
+        # Use zip_longest to create tuples of sorries from each repo position
+        sorry
+        for sorries_tuple in zip_longest(*repo_groups.values())
+        # and flatten the result while filtering out None values
+        for sorry in sorries_tuple
+        if sorry is not None
+    )
+
+    # Use islice to take only the first n elements from the generator
+    return list(islice(interleaved_sorries_generator, n))
+
+
 def deduplicate_database(
     database_path: Path,
     query_results_path: Optional[Path] = None,
+    max_sorries: Optional[int] = None,
 ):
     """
     Deduplicate the database and write the results to `query_results_path`.
@@ -37,10 +70,13 @@ def deduplicate_database(
 
     database.load_database(database_path)
 
-    deduplicated_sorries = {
-        "documentation": "deduplicated list of sorries, for each unique goal string the most recent inclusion date is chosen",
-        "sorries": deduplicate_sorries_by_goal(database.get_sorries())
-    }
+    deduplicated_sorries = deduplicate_sorries_by_goal(database.get_sorries())
+
+    if max_sorries:
+        deduplicated_sorries = varied_repo_frequent_n_sorries(
+            deduplicated_sorries, max_sorries
+        )
+
     if query_results_path:
         with open(query_results_path, "w") as f:
             json.dump(

--- a/tests/mock_sorries.py
+++ b/tests/mock_sorries.py
@@ -9,9 +9,11 @@ FEB_1 = datetime(2023, 2, 1, tzinfo=timezone.utc)
 
 
 # helper functions to create Sorry objects with default values for easier testing
-def repo_info_with_defaults() -> RepoInfo:
+def repo_info_with_defaults(
+    remote="https://github.com/test/repo",
+) -> RepoInfo:
     return RepoInfo(
-        remote="https://github.com/test/repo",
+        remote=remote,
         branch="main",
         commit="abcdef12345",
         lean_version="v4.16.0",
@@ -48,10 +50,14 @@ def metadata_with_defaults(
 def sorry_with_defaults(
     goal: str = "test goal",
     inclusion_date=JAN_1,
+    blame_date=JAN_1,
+    repo_remote="https://example.com/repo",
 ) -> Sorry:
     return Sorry(
-        repo=repo_info_with_defaults(),
+        repo=repo_info_with_defaults(remote=repo_remote),
         location=location_with_defaults(),
         debug_info=debug_info_with_defaults(goal=goal),
-        metadata=metadata_with_defaults(inclusion_date=inclusion_date),
+        metadata=metadata_with_defaults(
+            inclusion_date=inclusion_date, blame_date=blame_date
+        ),
     )

--- a/tests/test_deduplicate_database.py
+++ b/tests/test_deduplicate_database.py
@@ -1,9 +1,12 @@
 import json
+from datetime import datetime, timedelta, timezone
 
 from sorrydb.database.deduplicate_database import (
     deduplicate_database,
     deduplicate_sorries_by_goal,
+    varied_repo_frequent_n_sorries,
 )
+from sorrydb.database.sorry_database import JsonDatabase
 from tests.mock_sorries import FEB_1, JAN_1, JAN_15, sorry_with_defaults
 
 
@@ -61,4 +64,198 @@ def test_deduplicate_database_single_test_repo(
         query_results_json = json.load(f1)
         expected_query_results_json = json.load(f2)
 
-    assert query_results_json["sorries"] == expected_query_results_json
+    assert query_results_json == expected_query_results_json
+
+
+def test_deduplicate_database_multiple_repos_with_max_sorries(
+    update_db_multiple_repos_test_repo_path, tmp_path
+):
+    """Test that deduplicate_database with max_sorries limits the sorries
+    and selects them from different repositories when possible."""
+    tmp_write_query_results = tmp_path / "deduplicated_query_results_with_max.json"
+
+    # Set max_sorries to a specific value
+    max_sorries = 3
+
+    # Call deduplicate_database with max_sorries parameter
+    deduplicated_sorries = deduplicate_database(
+        database_path=update_db_multiple_repos_test_repo_path,
+        query_results_path=tmp_write_query_results,
+        max_sorries=max_sorries,
+    )
+
+    assert deduplicated_sorries is not None
+
+    # Verify the number of sorries doesn't exceed max_sorries
+    assert len(deduplicated_sorries) <= max_sorries
+
+    # Load the original database to verify varied repo selection
+    database = JsonDatabase()
+    database.load_database(update_db_multiple_repos_test_repo_path)
+    original_sorries = database.get_sorries()
+
+    # Get list of unique repos in original data
+    original_repos = {sorry.repo.remote for sorry in original_sorries}
+
+    # Verify the sorries come from different repos when possible
+    result_repos = {sorry.repo.remote for sorry in deduplicated_sorries}
+    assert len(result_repos) == min(len(original_repos), max_sorries)
+
+    # Verify the sorries from json file match the returned sorries
+    with open(tmp_write_query_results, "r") as f:
+        query_results_json = json.load(f)
+
+    expected_results = [
+        {
+            "repo": {
+                "remote": "https://github.com/austinletson/sorryClientTestRepo",
+                "branch": "master",
+                "commit": "f8632a130a6539d9f546a4ef7b412bc3d86c0f63",
+                "lean_version": "v4.16.0",
+            },
+            "location": {
+                "start_line": 10,
+                "start_column": 2,
+                "end_line": 10,
+                "end_column": 7,
+                "file": "SorryClientTestRepo/BasicWithElabTactic.lean",
+            },
+            "debug_info": {
+                "goal": "⊢ 1 + 4 = 5",
+                "url": "https://github.com/austinletson/sorryClientTestRepo/blob/f8632a130a6539d9f546a4ef7b412bc3d86c0f63/SorryClientTestRepo/BasicWithElabTactic.lean#L10",
+            },
+            "metadata": {
+                "blame_email_hash": "9fe2851ae6a7",
+                "blame_date": "2025-03-13T06:55:53-04:00",
+                "inclusion_date": "2025-03-27T22:13:52.041823+00:00",
+            },
+            "id": "32f0c31873bbf531a3e8b8b2bf6dd73f7e70c0525367f93a026ff36a95d5d49b",
+        },
+        {
+            "repo": {
+                "remote": "https://github.com/austinletson/sorryClientTestRepoMath",
+                "branch": "some_branch",
+                "commit": "c1c539f7432bafccd8eaf55f363eaad4e0b92374",
+                "lean_version": "v4.17.0-rc1",
+            },
+            "location": {
+                "start_line": 7,
+                "start_column": 45,
+                "end_line": 7,
+                "end_column": 50,
+                "file": "SorryClientTestRepoMath/WithImport.lean",
+            },
+            "debug_info": {
+                "goal": "X : Type\ninst✝ : TopologicalSpace X\n⊢ IsClosed Set.univ",
+                "url": "https://github.com/austinletson/sorryClientTestRepoMath/blob/c1c539f7432bafccd8eaf55f363eaad4e0b92374/SorryClientTestRepoMath/WithImport.lean#L7",
+            },
+            "metadata": {
+                "blame_email_hash": "24b3fae77efa",
+                "blame_date": "2025-03-07T20:58:44+01:00",
+                "inclusion_date": "2025-03-27T22:15:37.775456+00:00",
+            },
+            "id": "e15435bd01ddd9ee04d31a1c72ea9acbefb78d542b1bf53991b8c93abba49943",
+        },
+        {
+            "repo": {
+                "remote": "https://github.com/austinletson/sorryClientTestRepo",
+                "branch": "branch1",
+                "commit": "78202012bfe87f99660ba2fe5973eb1a8110ab64",
+                "lean_version": "v4.16.0",
+            },
+            "location": {
+                "start_line": 11,
+                "start_column": 2,
+                "end_line": 11,
+                "end_column": 7,
+                "file": "SorryClientTestRepo/BasicWithElabTactic.lean",
+            },
+            "debug_info": {
+                "goal": "⊢ 1 + 3 = 4",
+                "url": "https://github.com/austinletson/sorryClientTestRepo/blob/78202012bfe87f99660ba2fe5973eb1a8110ab64/SorryClientTestRepo/BasicWithElabTactic.lean#L11",
+            },
+            "metadata": {
+                "blame_email_hash": "9fe2851ae6a7",
+                "blame_date": "2025-03-11T18:28:42-04:00",
+                "inclusion_date": "2025-03-27T22:13:42.762667+00:00",
+            },
+            "id": "d4a88c0c3b53771bbdf3dea76fa3b1e3042921b49c1839060f9b3a9807a3cb9c",
+        },
+    ]
+
+    assert query_results_json == expected_results
+
+
+def test_varied_repo_frequent_n_sorries():
+    """Test that varied_repo_frequent_n_sorries selects sorries from different
+    repositories, prioritizing recent blame dates."""
+
+    # Create base date for testing
+    base_date = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+    # Create sorries from three different repos with varying blame dates
+    sorries = [
+        # Repo 1 - three sorries with different dates
+        sorry_with_defaults(
+            goal="repo1_goal1", blame_date=base_date, repo_remote="repo1"
+        ),
+        sorry_with_defaults(
+            goal="repo1_goal2",
+            blame_date=base_date + timedelta(days=5),
+            repo_remote="repo1",
+        ),
+        sorry_with_defaults(
+            goal="repo1_goal3",
+            blame_date=base_date + timedelta(days=10),  # Most recent for repo1
+            repo_remote="repo1",
+        ),
+        # Repo 2 - two sorries with different dates
+        sorry_with_defaults(
+            goal="repo2_goal1",
+            blame_date=base_date + timedelta(days=2),
+            repo_remote="repo2",
+        ),
+        sorry_with_defaults(
+            goal="repo2_goal2",
+            blame_date=base_date + timedelta(days=7),  # Most recent for repo2
+            repo_remote="repo2",
+        ),
+        # Repo 3 - one sorry
+        sorry_with_defaults(
+            goal="repo3_goal1",
+            blame_date=base_date + timedelta(days=3),
+            repo_remote="repo3",
+        ),
+    ]
+
+    # Test with n=2 (should get one from repo1 and one from repo2, both the most recent)
+    result = varied_repo_frequent_n_sorries(sorries, 2)
+    assert len(result) == 2
+
+    # Check that we got sorries from different repos
+    result_repos = {sorry.repo.remote for sorry in result}
+    assert len(result_repos) == 2
+
+    # Verify we got the most recent sorry from each repo
+    for repo in result_repos:
+        repo_sorries = [s for s in sorries if s.repo.remote == repo]
+        repo_sorry_in_result = [s for s in result if s.repo.remote == repo][0]
+        most_recent_sorry = max(repo_sorries, key=lambda s: s.metadata.blame_date)
+        assert repo_sorry_in_result.debug_info.goal == most_recent_sorry.debug_info.goal
+
+    # Test with n=4 (should get one from each repo, then one more from repo1)
+    result = varied_repo_frequent_n_sorries(sorries, 4)
+    assert len(result) == 4
+
+    # Check repo distribution
+    repo_counts = {}
+    for sorry in result:
+        repo_counts[sorry.repo.remote] = repo_counts.get(sorry.repo.remote, 0) + 1
+
+    # We should have all 3 repos represented
+    assert len(repo_counts) == 3
+    # Repo1 should have 2 sorries (since we need 4 total)
+    assert repo_counts["repo1"] == 2
+    # Repo2 and Repo3 should have 1 sorry each
+    assert repo_counts["repo2"] == 1
+    assert repo_counts["repo3"] == 1


### PR DESCRIPTION
This shouldn't be merged before feature freeze

This is useful for creating static benchmarks of `n` sorries