### PR TITLE
git_ops error handling

### DIFF
--- a/sorrydb/agents/json_agent.py
+++ b/sorrydb/agents/json_agent.py
@@ -84,9 +84,6 @@ class JsonAgent:
                 sorry.repo.commit,
                 lean_data_dir,
             )
-            if not checkout_path:
-                logger.error(f"Failed to prepare repository: {sorry.repo.remote}")
-                raise Exception(f"Failed to prepare repository: {sorry.repo.remote}")
 
             # Build the Lean project
             build_lean_project(checkout_path)

--- a/sorrydb/agents/rfl_agent/__init__.py
+++ b/sorrydb/agents/rfl_agent/__init__.py
@@ -1,3 +1,0 @@
-"""
-REPL client module for processing sorry instances.
-"""

--- a/sorrydb/database/build_database.py
+++ b/sorrydb/database/build_database.py
@@ -166,9 +166,10 @@ def repo_has_updates(repo: dict) -> Optional[str]:
     remote_url = repo["remote_url"]
     logger.info(f"Checking repository for new commits: {remote_url}")
 
-    current_hash = remote_heads_hash(remote_url)
-    if current_hash is None:
-        logger.warning(f"Could not get remote heads hash for {remote_url}, skipping")
+    try:
+        current_hash = remote_heads_hash(remote_url)
+    except RuntimeError:
+        logger.warning(f"Could not get remote heads hash for {remote_url}, skipping.")
         return None
 
     if current_hash == repo["remote_heads_hash"]:

--- a/sorrydb/database/build_database.py
+++ b/sorrydb/database/build_database.py
@@ -168,8 +168,10 @@ def repo_has_updates(repo: dict) -> Optional[str]:
 
     try:
         current_hash = remote_heads_hash(remote_url)
-    except RuntimeError:
-        logger.warning(f"Could not get remote heads hash for {remote_url}, skipping.")
+    except Exception:
+        logger.exception(
+            f"Could not get remote heads hash for {remote_url}, skipping."
+        )
         return None
 
     if current_hash == repo["remote_heads_hash"]:

--- a/sorrydb/database/process_sorries.py
+++ b/sorrydb/database/process_sorries.py
@@ -240,9 +240,6 @@ def prepare_and_process_lean_repo(
 
     # Prepare the repository (clone/checkout)
     checkout_path = prepare_repository(repo_url, branch, None, lean_data)
-    if not checkout_path:
-        logger.error(f"Failed to prepare repository: {repo_url}")
-        raise Exception(f"Failed to prepare repository: {repo_url}")
 
     # Get Lean version from repo
     try:

--- a/sorrydb/utils/git_ops.py
+++ b/sorrydb/utils/git_ops.py
@@ -222,7 +222,7 @@ def remote_heads(remote_url: str) -> list[dict]:
         return []
 
 
-def remote_heads_hash(remote_url: str) -> str:
+def remote_heads_hash(remote_url: str) -> str | None:
     """Get a hash of the (sorted) set of unique branch heads in a remote repository.
 
     Args:
@@ -230,26 +230,17 @@ def remote_heads_hash(remote_url: str) -> str:
 
     Returns:
         First 12 characters of SHA-256 hash of sorted set of unique head SHAs
-
-    Raises:
-        RuntimeError: If there is an error getting the remote heads
     """
-    try:
-        heads = remote_heads(remote_url)
-        if not heads:
-            raise RuntimeError(f"No branches found for {remote_url}")
+    heads = remote_heads(remote_url)
+    if not heads:
+        return None
 
-        # Extract unique SHAs and sort them
-        shas = sorted(set(head["sha"] for head in heads))
-        # Join them with a delimiter and hash
-        combined = "_".join(shas)
-        return hashlib.sha256(combined.encode()).hexdigest()[:12]
+    # Extract unique SHAs and sort them
+    shas = sorted(set(head["sha"] for head in heads))
+    # Join them with a delimiter and hash
+    combined = "_".join(shas)
+    return hashlib.sha256(combined.encode()).hexdigest()[:12]
 
-    except Exception as e:
-        logger.error(
-            f"Error computing sorted hash of remote heads for {remote_url}: {e}"
-        )
-        raise RuntimeError(f"Error computing sorted hash of remote heads for {remote_url}: {e}")
 
 
 def leaf_commits(remote_url: str) -> list[dict]:

--- a/sorrydb/utils/git_ops.py
+++ b/sorrydb/utils/git_ops.py
@@ -193,33 +193,28 @@ def remote_heads(remote_url: str) -> list[dict]:
             - branch: name of the branch
             - sha: SHA of the HEAD commit
     """
-    try:
-        # Use git.cmd.Git for running git commands directly
-        logger.debug(f"Getting remote heads for {remote_url}")
-        git_cmd = git.cmd.Git()
-        logger.debug(f"Running git command: git ls-remote --heads {remote_url}")
-        output = git_cmd.ls_remote("--heads", remote_url)
+    # Use git.cmd.Git for running git commands directly
+    logger.debug(f"Getting remote heads for {remote_url}")
+    git_cmd = git.cmd.Git()
+    logger.debug(f"Running git command: git ls-remote --heads {remote_url}")
+    output = git_cmd.ls_remote("--heads", remote_url)
 
-        # Parse the output into a list of dicts
-        heads = []
-        for line in output.splitlines():
-            if not line.strip():
-                continue
+    # Parse the output into a list of dicts
+    heads = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
 
-            # Each line is of format: "<sha>\trefs/heads/<branch>"
-            sha, ref = line.split("\t")
-            branch = ref.replace("refs/heads/", "")
+        # Each line is of format: "<sha>\trefs/heads/<branch>"
+        sha, ref = line.split("\t")
+        branch = ref.replace("refs/heads/", "")
 
-            heads.append({"branch": branch, "sha": sha})
-        if len(heads) == 0:
-            logger.warning(f"No branches found for {remote_url}")
-        else:
-            logger.debug(f"Found {len(heads)} branches in {remote_url}")
-        return heads
-
-    except Exception as e:
-        logger.error(f"Error getting remote heads for {remote_url}: {e}")
-        return []
+        heads.append({"branch": branch, "sha": sha})
+    if len(heads) == 0:
+        logger.warning(f"No branches found for {remote_url}")
+    else:
+        logger.debug(f"Found {len(heads)} branches in {remote_url}")
+    return heads
 
 
 def remote_heads_hash(remote_url: str) -> str | None:

--- a/sorrydb/utils/git_ops.py
+++ b/sorrydb/utils/git_ops.py
@@ -111,8 +111,11 @@ def get_head_sha(remote_url: str, branch: str = None) -> str:
 
 
 def prepare_repository(
-    remote_url: str, branch: str, head_sha: Optional[str], lean_data: Path
-) -> Optional[Path]:
+    remote_url: str,
+    branch: str,
+    head_sha: Optional[str],
+    lean_data: Path,
+) -> Path:
     """Prepare a repository for analysis by cloning or updating it and checking out a specific commit.
 
     Args:
@@ -122,7 +125,10 @@ def prepare_repository(
         lean_data: Base directory for checkouts
 
     Returns:
-        Path to checked out repository or None if failed
+        Path to checked out repository
+
+    Raises:
+        RuntimeError: If cloning or checking out fails
     """
     # Create a directory name from the remote URL
     repo_name = remote_url.rstrip("/").split("/")[-1]
@@ -143,7 +149,7 @@ def prepare_repository(
 
         except Exception as e:
             logger.error(f"Error cloning repository: {e}")
-            return None
+            raise RuntimeError(f"Error cloning repository: {e}")
     else:  # Repository already exists, open it and fetch latest changes
         try:
             logger.info(
@@ -153,7 +159,7 @@ def prepare_repository(
             repo.git.fetch("--all")
         except Exception as e:
             logger.error(f"Error fetching latest changes: {e}")
-            return None
+            raise RuntimeError(f"Error fetching latest changes: {e}")
 
     # Checkout specific commit
     try:
@@ -162,7 +168,7 @@ def prepare_repository(
         return checkout_path
     except Exception as e:
         logger.error(f"Error checking out commit {head_sha}: {e}")
-        return None
+        raise RuntimeError(f"Error checking out commit {head_sha}: {e}")
 
 
 def get_default_branch(repo_path: Path) -> str:

--- a/sorrydb/utils/git_ops.py
+++ b/sorrydb/utils/git_ops.py
@@ -222,19 +222,22 @@ def remote_heads(remote_url: str) -> list[dict]:
         return []
 
 
-def remote_heads_hash(remote_url: str) -> str | None:
+def remote_heads_hash(remote_url: str) -> str:
     """Get a hash of the (sorted) set of unique branch heads in a remote repository.
 
     Args:
         remote_url: Git remote URL (HTTPS or SSH)
 
     Returns:
-        First 12 characters of SHA-256 hash of sorted set of unique head SHAs, or None if error
+        First 12 characters of SHA-256 hash of sorted set of unique head SHAs
+
+    Raises:
+        RuntimeError: If there is an error getting the remote heads
     """
     try:
         heads = remote_heads(remote_url)
         if not heads:
-            return None
+            raise RuntimeError(f"No branches found for {remote_url}")
 
         # Extract unique SHAs and sort them
         shas = sorted(set(head["sha"] for head in heads))
@@ -246,7 +249,7 @@ def remote_heads_hash(remote_url: str) -> str | None:
         logger.error(
             f"Error computing sorted hash of remote heads for {remote_url}: {e}"
         )
-        return None
+        raise RuntimeError(f"Error computing sorted hash of remote heads for {remote_url}: {e}")
 
 
 def leaf_commits(remote_url: str) -> list[dict]:


### PR DESCRIPTION
`prepare_repository` and `remote_heads_hash` now raise errors in stead of returning `None`. Closes #122 