### PR TITLE
feat: improved database update stats and report

### DIFF
--- a/sorrydb/cli/update_db.py
+++ b/sorrydb/cli/update_db.py
@@ -40,6 +40,14 @@ def update(
             dir_okay=False,
         ),
     ] = None,
+    report_file_path: Annotated[
+        Optional[Path],
+        typer.Option(
+            help="Path to write markdown update report",
+            file_okay=True,
+            dir_okay=False,
+        ),
+    ] = None,
 ):
     """
     Update an existing SorryDB database.
@@ -51,6 +59,7 @@ def update(
             database_path=database_path,
             lean_data_path=lean_data_path,
             stats_file=stats_file_path,
+            report_file=report_file_path,
         )
         return 0
     except Exception as e:

--- a/sorrydb/database/build_database.py
+++ b/sorrydb/database/build_database.py
@@ -169,9 +169,7 @@ def repo_has_updates(repo: dict) -> Optional[str]:
     try:
         current_hash = remote_heads_hash(remote_url)
     except Exception:
-        logger.exception(
-            f"Could not get remote heads hash for {remote_url}, skipping."
-        )
+        logger.exception(f"Could not get remote heads hash for {remote_url}, skipping.")
         return None
 
     if current_hash == repo["remote_heads_hash"]:
@@ -264,6 +262,7 @@ def update_database(
     write_database_path: Optional[Path] = None,
     lean_data_path: Optional[Path] = None,
     stats_file: Optional[Path] = None,
+    report_file: Optional[Path] = None,
 ) -> dict:
     """
     Update a SorryDatabase by checking for changes in repositories and processing new commits.
@@ -290,5 +289,8 @@ def update_database(
     database.write_database(write_database_path)
     if stats_file:
         database.write_stats(stats_file)
+
+    if report_file:
+        database.write_stats_report(report_file)
 
     return database.update_stats

--- a/sorrydb/database/sorry_database.py
+++ b/sorrydb/database/sorry_database.py
@@ -3,6 +3,7 @@ import logging
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 from sorrydb.database.sorry import Sorry, SorryJSONEncoder, sorry_object_hook
 
@@ -19,7 +20,6 @@ class JsonDatabase:
                 "new_leaf_commit": None,
                 "start_processing_time": None,
                 "end_processing_time": None,
-                "total_processing_time": None,
                 "lake_timeout": None,
             }
         )
@@ -32,29 +32,6 @@ class JsonDatabase:
 
     def set_end_processing_time(self, repo_url, end_processing_time):
         self.update_stats[repo_url]["end_processing_time"] = end_processing_time
-        self._update_total_processing_time(repo_url)
-
-    def _update_total_processing_time(self, repo_url):
-        start_time = self.update_stats[repo_url]["start_processing_time"]
-        end_time = self.update_stats[repo_url]["end_processing_time"]
-
-        if start_time and end_time:
-            start_dt = datetime.fromisoformat(start_time)
-            end_dt = datetime.fromisoformat(end_time)
-            total_seconds = (end_dt - start_dt).total_seconds()
-
-            # Format the time in a human-readable format
-            hours, remainder = divmod(int(total_seconds), 3600)
-            minutes, seconds = divmod(remainder, 60)
-
-            if hours > 0:
-                human_readable = f"{hours}h {minutes}m {seconds}s"
-            elif minutes > 0:
-                human_readable = f"{minutes}m {seconds}s"
-            else:
-                human_readable = f"{seconds}s"
-
-            self.update_stats[repo_url]["total_processing_time"] = human_readable
 
     def set_lake_timeout(self, repo_url, lake_timeout):
         self.update_stats[repo_url]["lake_timeout"] = lake_timeout
@@ -69,19 +46,12 @@ class JsonDatabase:
         """
         logger.info(f"Loading sorry database from {database_path}")
 
-        try:
-            with open(database_path, "r", encoding="utf-8") as f:
-                # use sorry_object_hook to automatically create Sorry instances
-                database_dict = json.load(f, object_hook=sorry_object_hook)
+        with open(database_path, "r", encoding="utf-8") as f:
+            # use sorry_object_hook to automatically create Sorry instances
+            database_dict = json.load(f, object_hook=sorry_object_hook)
 
-            self.repos = database_dict["repos"]
-            self.sorries = database_dict["sorries"]
-        except FileNotFoundError:
-            logger.error(f"Database file not found: {database_path}")
-            raise FileNotFoundError(f"Database file not found: {database_path}")
-        except json.JSONDecodeError:
-            logger.error(f"Invalid JSON in database file: {database_path}")
-            raise ValueError(f"Invalid JSON in database file: {database_path}")
+        self.repos = database_dict["repos"]
+        self.sorries = database_dict["sorries"]
 
     def get_all_repos(self):
         return self.repos
@@ -128,3 +98,101 @@ class JsonDatabase:
                 indent=2,
             )
         logger.info("Database stats written successfully")
+
+    def aggregate_update_stats(self) -> tuple:
+        """
+        Uses self.update_stats to calculate aggregate update stats:
+        - total number of repos with new commits
+        - total number of repos with a lake timeout
+        - total number of sorries
+        - total number of new sorries
+        """
+        repos_with_new_commits = 0
+        repos_with_lake_timeout = 0
+        total_sorries_count = 0
+        total_new_goal_sorries_count = 0
+
+        for stats in self.update_stats.values():
+            if stats["new_leaf_commit"] is not None:
+                repos_with_new_commits += 1
+
+            if stats["lake_timeout"] is True:
+                repos_with_lake_timeout += 1
+
+            for commit_stats in stats["counts"].values():
+                total_sorries_count += commit_stats["count"]
+                total_new_goal_sorries_count += commit_stats["count_new_goal"]
+
+        return (
+            repos_with_new_commits,
+            repos_with_lake_timeout,
+            total_sorries_count,
+            total_new_goal_sorries_count,
+        )
+
+    @staticmethod
+    def _calculate_human_readable_processing_time(
+        start_time_iso: str, end_time_iso: str
+    ) -> str:
+        start_dt = datetime.fromisoformat(start_time_iso)
+        end_dt = datetime.fromisoformat(end_time_iso)
+
+        total_seconds = (end_dt - start_dt).total_seconds()
+
+        hours, remainder = divmod(int(total_seconds), 3600)
+        minutes, seconds = divmod(remainder, 60)
+
+        if hours > 0:
+            return f"{hours}h {minutes}m {seconds}s"
+        elif minutes > 0:
+            return f"{minutes}m {seconds}s"
+        else:
+            return f"{seconds}s"
+
+    def write_stats_report(self, report_path: Path):
+        """
+        Aggregates update stats and writes a markdown based report to the `report_path`
+        """
+        (
+            repos_with_new_commits,
+            repos_with_lake_timeout,
+            total_sorries_count,
+            total_new_goal_sorries_count,
+        ) = self.aggregate_update_stats()
+
+        report_content = f"""# SorryDB Update Stats report
+
+## Summary
+
+- **Repositories with new commits:** {repos_with_new_commits}
+- **Repositories with lake timeout:** {repos_with_lake_timeout}
+- **Total sorries found:** {total_sorries_count}
+- **Total new goal sorries found:** {total_new_goal_sorries_count}
+
+## Detailed Stats per Repository
+
+| Repository URL | Lake Timeout | Processing Time | Sorries | New Goal Sorries |
+|----------------|--------------|-----------------|---------|------------------|
+"""
+
+        for repo_url, stats in self.update_stats.items():
+            # Don't add repos with no new leaf commits to report
+            if not stats["new_leaf_commit"]:
+                break
+
+            lake_timeout_status = "Yes" if stats["lake_timeout"] else "No"
+            processing_time = self._calculate_human_readable_processing_time(
+                stats["start_processing_time"], stats["end_processing_time"]
+            )
+
+            repo_total_sorries = 0
+            repo_total_new_goal_sorries = 0
+            for commit_stats in stats["counts"].values():
+                repo_total_sorries += commit_stats["count"]
+                repo_total_new_goal_sorries += commit_stats["count_new_goal"]
+
+            report_content += f"| {repo_url} | {lake_timeout_status} | {processing_time} | {repo_total_sorries} | {repo_total_new_goal_sorries} |\n"
+
+        with open(report_path, "w", encoding="utf-8") as f:
+            f.write(report_content)
+        logger.info(f"Stats report written successfully to {report_path}")

--- a/sorrydb/database/sorry_database.py
+++ b/sorrydb/database/sorry_database.py
@@ -3,7 +3,6 @@ import logging
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 from sorrydb.database.sorry import Sorry, SorryJSONEncoder, sorry_object_hook
 

--- a/tests/test_json_database.py
+++ b/tests/test_json_database.py
@@ -1,18 +1,14 @@
-from pathlib import Path
-
 from sorrydb.database.sorry_database import JsonDatabase
 from tests.mock_sorries import sorry_with_defaults
 
 
 def test_json_database_load_database(update_db_single_test_repo_path):
     database = JsonDatabase()
-
     database.load_database(update_db_single_test_repo_path)
 
 
 def test_json_database_add_sorry(update_db_single_test_repo_path):
     database = JsonDatabase()
-
     database.load_database(update_db_single_test_repo_path)
 
     length_before_add = len(database.sorries)
@@ -26,7 +22,6 @@ def test_json_database_add_sorry(update_db_single_test_repo_path):
 
 def test_json_database_aggregate_update_stats(update_db_single_test_repo_path):
     database = JsonDatabase()
-
     database.load_database(update_db_single_test_repo_path)
 
     database.add_sorry(sorry_with_defaults())
@@ -37,7 +32,6 @@ def test_json_database_aggregate_update_stats(update_db_single_test_repo_path):
 
 
 def test_calculate_human_readable_processing_time():
-    # Test cases for _calculate_human_readable_processing_time
     assert (
         JsonDatabase._calculate_human_readable_processing_time(
             "2023-10-26T10:00:00", "2023-10-26T10:00:30"

--- a/tests/test_json_database.py
+++ b/tests/test_json_database.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+from sorrydb.database.sorry_database import JsonDatabase
+from tests.mock_sorries import sorry_with_defaults
+
+
+def test_json_database_load_database(update_db_single_test_repo_path):
+    database = JsonDatabase()
+
+    database.load_database(update_db_single_test_repo_path)
+
+
+def test_json_database_add_sorry(update_db_single_test_repo_path):
+    database = JsonDatabase()
+
+    database.load_database(update_db_single_test_repo_path)
+
+    length_before_add = len(database.sorries)
+
+    database.add_sorry(sorry_with_defaults())
+
+    length_after_add = len(database.sorries)
+
+    assert (length_after_add - length_before_add) == 1
+
+
+def test_json_database_aggregate_update_stats(update_db_single_test_repo_path):
+    database = JsonDatabase()
+
+    database.load_database(update_db_single_test_repo_path)
+
+    database.add_sorry(sorry_with_defaults())
+
+    aggregate_update_stats = database.aggregate_update_stats()
+
+    assert aggregate_update_stats == (0, 0, 1, 1)
+
+
+def test_calculate_human_readable_processing_time():
+    # Test cases for _calculate_human_readable_processing_time
+    assert (
+        JsonDatabase._calculate_human_readable_processing_time(
+            "2023-10-26T10:00:00", "2023-10-26T10:00:30"
+        )
+        == "30s"
+    )
+    assert (
+        JsonDatabase._calculate_human_readable_processing_time(
+            "2023-10-26T10:00:00", "2023-10-26T10:02:30"
+        )
+        == "2m 30s"
+    )
+    assert (
+        JsonDatabase._calculate_human_readable_processing_time(
+            "2023-10-26T10:00:00", "2023-10-26T11:05:15"
+        )
+        == "1h 5m 15s"
+    )
+    assert (
+        JsonDatabase._calculate_human_readable_processing_time(
+            "2023-10-26T10:00:00", "2023-10-26T10:00:00"
+        )
+        == "0s"
+    )


### PR DESCRIPTION
Add human-readable markdown reports with aggregated statistics to sorrydb updates.

Add a `--report-file-path` option to `sorrydb update` command.


Here is a sample report:

# SorryDB Update Stats report

## Summary

- **Repositories with new commits:** 1
- **Repositories with lake timeout:** 0
- **Total sorries found:** 7
- **Total new goal sorries found:** 3

## Detailed Stats per Repository

| Repository URL | Lake Timeout | Processing Time | Sorries | New Goal Sorries |
|----------------|--------------|-----------------|---------|------------------|
| https://github.com/austinletson/sorryClientTestRepo | No | 15s | 7 | 3 |


Closes #60