### PR TITLE
chore: use ruff default linting configuration

### DIFF
--- a/doc/Introduction_to_the_SorryDB_Project.ipynb
+++ b/doc/Introduction_to_the_SorryDB_Project.ipynb
@@ -45,7 +45,6 @@
    ],
    "source": [
     "import calendar\n",
-    "import json\n",
     "import random\n",
     "from collections import Counter\n",
     "from datetime import datetime\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,6 @@ deploy_sorrydb = "orchestration.deploy:app"
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.ruff.lint]
-select = ["I"]
-
 [tool.pytest.ini_options]
 # do not retain tmp_paths because tests create large `.lake` folders which we want to remove after every test
 tmp_path_retention_policy = "none"

--- a/sorrydb/agents/llm_strategy.py
+++ b/sorrydb/agents/llm_strategy.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from pathlib import Path
 from typing import Dict
@@ -101,7 +100,7 @@ class LLMStrategy(SorryStrategy):
 
         # Remove empty lines and base indentation
         lines = [line for line in proof.split("\n") if line.strip()]
-        
+
         if not lines:
             return ""
 
@@ -147,9 +146,9 @@ class LLMStrategy(SorryStrategy):
         file_text = file_path.read_text()
 
         # Extract the context up to the sorry line
-        context_lines = file_text.splitlines()[:loc.start_line]
+        context_lines = file_text.splitlines()[: loc.start_line]
         context = "\n".join(context_lines)
-        
+
         prompt = PROMPT.format(
             goal=sorry.debug_info.goal,
             context=context,

--- a/sorrydb/agents/rfl_strategy.py
+++ b/sorrydb/agents/rfl_strategy.py
@@ -1,11 +1,8 @@
 from sorrydb.agents.json_agent import SorryStrategy
 from sorrydb.database.sorry import Sorry
 from pathlib import Path
-from typing import Dict
 
 
 class RflStrategy(SorryStrategy):
     def prove_sorry(self, repo_path: Path, sorry: Sorry) -> str | None:
         return "rfl"
-
-

--- a/sorrydb/cli/scrape_reservoir.py
+++ b/sorrydb/cli/scrape_reservoir.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import datetime
 from datetime import datetime, timezone
 
 from sorrydb.database.reservoir import scrape_reservoir

--- a/sorrydb/database/reservoir.py
+++ b/sorrydb/database/reservoir.py
@@ -1,8 +1,7 @@
-import argparse
 import json
 import subprocess
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 

--- a/sorrydb/utils/repl_ops.py
+++ b/sorrydb/utils/repl_ops.py
@@ -4,7 +4,7 @@ import json
 import logging
 import subprocess
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 from git import Repo
 
@@ -263,7 +263,7 @@ class LeanRepl:
                         return parent_type
 
         # If we don't find the goal parent type, raise an exception
-        raise RuntimeError(f"REPL tactic did not return parent type")
+        raise RuntimeError("REPL tactic did not return parent type")
 
     def find_sorry_proof_state(self, location: dict) -> Tuple[int, str]:
         """Find the proof state of a sorry.

--- a/sorrydb/utils/verify.py
+++ b/sorrydb/utils/verify.py
@@ -3,7 +3,6 @@
 import logging
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Optional
 
 from .repl_ops import LeanRepl, setup_repl
 from sorrydb.database.sorry import Location
@@ -11,7 +10,9 @@ from sorrydb.database.sorry import Location
 logger = logging.getLogger(__name__)
 
 
-def verify_proof(repo_dir: Path, lean_version: str, location: Location, proof: str) -> bool:
+def verify_proof(
+    repo_dir: Path, lean_version: str, location: Location, proof: str
+) -> bool:
     """
     Verify if a proof successfully replaces a sorry at a specific location.
 
@@ -33,9 +34,7 @@ def verify_proof(repo_dir: Path, lean_version: str, location: Location, proof: s
     start_index = position_to_index(
         original_file, location.start_line, location.start_column
     )
-    end_index = position_to_index(
-        original_file, location.end_line, location.end_column
-    )
+    end_index = position_to_index(original_file, location.end_line, location.end_column)
 
     # Replace sorry with proof
     modified_file = original_file[:start_index] + proof + original_file[end_index:]

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -67,5 +67,5 @@ def test_default_values():
 
 def test_invalid_log_level_validation(monkeypatch):
     monkeypatch.setenv("SORRYDB_LOG_LEVEL", "INVALID_LEVEL")
-    with pytest.raises(ValidationError) as excinfo:
+    with pytest.raises(ValidationError):
         SorryDBSettings()

--- a/tests/test_build_database.py
+++ b/tests/test_build_database.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 
 import pytest

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -37,7 +37,7 @@ def test_verify_proofs():
             start_line=location_dict["start_line"],
             start_column=location_dict["start_column"],
             end_line=location_dict["end_line"],
-            end_column=location_dict["end_column"]
+            end_column=location_dict["end_column"],
         )
         proof = proof_entry["proof"]
 
@@ -60,7 +60,7 @@ def test_verify_proofs():
             start_line=location_dict["start_line"],
             start_column=location_dict["start_column"],
             end_line=location_dict["end_line"],
-            end_column=location_dict["end_column"]
+            end_column=location_dict["end_column"],
         )
         proof = proof_entry["proof"]
 


### PR DESCRIPTION
Previously we only used a few rules.
Now that the codebase is growing, extend to the full default rule set.

Note, some rules may now require manual fixing,
i.e., they want be automatically fixed by `ruff check --fix`