### PR TITLE
fix: resolve symlinks in verify_proof for macOS compatibility

### DIFF
--- a/sorrydb/utils/verify.py
+++ b/sorrydb/utils/verify.py
@@ -51,7 +51,7 @@ def verify_proof(
         tmp.flush()  # Ensure all data is written to disk
 
         # Get the relative path from repo_dir to the temp file
-        temp_path = Path(tmp.name)
+        temp_path = Path(tmp.name).resolve()
         # repo_dir must be resolve if it is a relative path
         modified_file_path = temp_path.relative_to(repo_dir.resolve())
 


### PR DESCRIPTION
On macOS, /var/folders/ is a symlink to /private/var/folders/. This caused path validation errors when computing relative paths between the repository directory and temporary files. Resolving both paths ensures consistent behavior across platforms.